### PR TITLE
Add credentials provider

### DIFF
--- a/src/main/kotlin/com/sypht/OAuthClient.kt
+++ b/src/main/kotlin/com/sypht/OAuthClient.kt
@@ -1,7 +1,7 @@
 package com.sypht
 
 import com.sypht.helper.Constants
-import com.sypht.helper.PropertyHelper
+import com.sypht.auth.ICredentialProvider
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -14,7 +14,8 @@ import java.util.logging.Logger
 /**
  * Log-in to the Sypht API
  */
-class OAuthClient(val requestTimeout: Long = 30) {
+class OAuthClient(val requestTimeout: Long = 30, val credentialProvider: ICredentialProvider) {
+
     private var clientId: String? = null
     private var clientSecret: String? = null
     private var oauthAudience: String? = null
@@ -25,22 +26,12 @@ class OAuthClient(val requestTimeout: Long = 30) {
      * set as environment variables.
      */
     init {
-        clientId = PropertyHelper.getEnvOrProperty("OAUTH_CLIENT_ID")
-        clientSecret = PropertyHelper.getEnvOrProperty("OAUTH_CLIENT_SECRET")
-        if (clientId == null && clientSecret == null) {
-            val syphtApiKey = PropertyHelper.getEnvOrProperty("SYPHT_API_KEY")
-            if (syphtApiKey != null) {
-                clientId = syphtApiKey.split(":")[0]
-                clientSecret = syphtApiKey.split(":")[1]
-            }
-        }
+        clientId = credentialProvider.clientId
+        clientSecret = credentialProvider.clientSecret
         if (clientId == null || clientSecret == null) {
             throw RuntimeException("SYPHT_API_KEY -OR- OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET environment" + " variables must be set before running this process, exiting")
         }
-        oauthAudience = PropertyHelper.getEnvOrProperty("OAUTH_AUDIENCE")
-        if (oauthAudience == null) {
-            oauthAudience = "https://api.sypht.com"
-        }
+        oauthAudience = credentialProvider.oauthAudience
     }
 
     /**

--- a/src/main/kotlin/com/sypht/SyphtClient.kt
+++ b/src/main/kotlin/com/sypht/SyphtClient.kt
@@ -1,6 +1,8 @@
 package com.sypht
 
+import com.sypht.auth.EnvironmentVariableCredentialProvider
 import com.sypht.helper.Constants
+import com.sypht.auth.ICredentialProvider
 import com.sypht.helper.InputStreamRequestBody
 import com.sypht.helper.PropertyHelper
 import io.jsonwebtoken.Claims
@@ -18,7 +20,7 @@ import java.util.logging.Logger
 /**
  * Connect to the Sypht API at https://api.sypht.com
  */
-open class SyphtClient() {
+open class SyphtClient(credentialProvider: ICredentialProvider = EnvironmentVariableCredentialProvider()) {
     private var bearerToken: String? = null
     private var okHttpClient: OkHttpClient? = null
     private var oauthClient: OAuthClient
@@ -31,7 +33,7 @@ open class SyphtClient() {
      */
     init {
         configureRequestTimeout()
-        oauthClient = OAuthClient(requestTimeout)
+        oauthClient = OAuthClient(requestTimeout, credentialProvider)
     }
 
     /**

--- a/src/main/kotlin/com/sypht/auth/AbsCredentialProvider.kt
+++ b/src/main/kotlin/com/sypht/auth/AbsCredentialProvider.kt
@@ -1,0 +1,10 @@
+package com.sypht.auth
+
+abstract class AbsCredentialProvider: ICredentialProvider {
+    private var userSetAudience: String = ""
+    override var oauthAudience: String
+        get() = if (userSetAudience.isNullOrEmpty()) "https://api.sypht.com" else userSetAudience
+        set(audience) {
+            userSetAudience = audience
+        }
+}

--- a/src/main/kotlin/com/sypht/auth/BasicCredentialProvider.kt
+++ b/src/main/kotlin/com/sypht/auth/BasicCredentialProvider.kt
@@ -1,0 +1,3 @@
+package com.sypht.auth
+
+class BasicCredentialProvider(override val clientId: String, override val clientSecret: String) : AbsCredentialProvider()

--- a/src/main/kotlin/com/sypht/auth/EnvironmentVariableCredentialProvider.kt
+++ b/src/main/kotlin/com/sypht/auth/EnvironmentVariableCredentialProvider.kt
@@ -1,0 +1,15 @@
+package com.sypht.auth
+
+import com.sypht.helper.PropertyHelper
+
+class EnvironmentVariableCredentialProvider : AbsCredentialProvider() {
+    init {
+        this.oauthAudience = PropertyHelper.getEnvOrProperty("OAUTH_AUDIENCE") ?: ""
+    }
+    override val clientId: String
+        get() = PropertyHelper.getEnvOrProperty("OAUTH_CLIENT_ID")
+                ?: PropertyHelper.getEnvOrProperty("SYPHT_API_KEY")?.split(':')?.get(0).toString() ?: ""
+    override val clientSecret: String
+        get() = PropertyHelper.getEnvOrProperty("OAUTH_CLIENT_SECRET")
+                ?: PropertyHelper.getEnvOrProperty("SYPHT_API_KEY")?.split(':')?.get(1).toString() ?: ""
+}

--- a/src/main/kotlin/com/sypht/auth/ICredentialProvider.kt
+++ b/src/main/kotlin/com/sypht/auth/ICredentialProvider.kt
@@ -1,0 +1,10 @@
+package com.sypht.auth
+
+/**
+ * @author
+ */
+interface ICredentialProvider {
+    val clientId: String
+    val clientSecret: String
+    var oauthAudience: String
+}

--- a/src/test/kotlin/com/sypht/OAuthClientTest.kt
+++ b/src/test/kotlin/com/sypht/OAuthClientTest.kt
@@ -1,5 +1,7 @@
 package com.sypht
 
+import com.sypht.auth.BasicCredentialProvider
+import com.sypht.auth.EnvironmentVariableCredentialProvider
 import junit.framework.TestCase
 import org.junit.Rule
 import org.junit.Test
@@ -11,18 +13,53 @@ import org.junit.rules.ExpectedException
  */
 class OAuthClientTest {
     @Rule @JvmField
-    final val environmentVariables = EnvironmentVariables()
+    val environmentVariables = EnvironmentVariables()
     @Rule @JvmField
-    final val exceptionRule = ExpectedException.none();
+    val exceptionRule = ExpectedException.none();
 
     /**
      * Test the OAuth Login
      */
     @Test
-    fun login() {
-        val client = OAuthClient()
+    fun loginUsingEnvironmentVariables() {
+        val client = OAuthClient(credentialProvider = EnvironmentVariableCredentialProvider())
         val token = client.login()
+
         TestCase.assertTrue("doesn't look like a JWT Token", token.startsWith("eyJ0"))
+    }
+
+    @Test
+    fun testBasicCredentials() {
+        val cp = BasicCredentialProvider("abc", "def")
+        var client = OAuthClient(credentialProvider = cp)
+
+        TestCase.assertEquals("Client ID does not match", "abc", getFieldByNameUsingReflection(client, "clientId"))
+        TestCase.assertEquals("Client Secret does not match", "def", getFieldByNameUsingReflection(client, "clientSecret"))
+        TestCase.assertNotNull("Audience is null", getFieldByNameUsingReflection(client, "oauthAudience"))
+        TestCase.assertFalse("Audience is empty", getFieldByNameUsingReflection(client, "oauthAudience") == "")
+
+        cp.oauthAudience = "ghi"
+        client = OAuthClient(credentialProvider = cp)
+
+        TestCase.assertEquals("Audience does not match", "ghi", getFieldByNameUsingReflection(client, "oauthAudience"))
+    }
+
+    @Test
+    fun testEnvironmentVariableCredentialProvider() {
+        environmentVariables.set("OAUTH_CLIENT_ID", "invalidClientId")
+        environmentVariables.set("OAUTH_CLIENT_SECRET", "invalidClientSecret")
+        environmentVariables.set("OAUTH_AUDIENCE", "invalidAudience")
+        val client = OAuthClient(credentialProvider = EnvironmentVariableCredentialProvider())
+
+        TestCase.assertEquals("Client ID does not match", "invalidClientId", getFieldByNameUsingReflection(client, "clientId"))
+        TestCase.assertEquals("Client Secret does not match", "invalidClientSecret", getFieldByNameUsingReflection(client, "clientSecret"))
+        TestCase.assertEquals("Client Secret does not match", "invalidAudience", getFieldByNameUsingReflection(client, "oauthAudience"))
+    }
+
+    private fun getFieldByNameUsingReflection(obj: Any, fieldName: String): Any? {
+        val f = obj.javaClass.declaredFields.first { it.name == fieldName}
+        f.isAccessible = true
+        return f.get(obj)
     }
 
     /**
@@ -34,7 +71,7 @@ class OAuthClientTest {
         exceptionRule.expectMessage("Client didn't respond with appropriate result")
         environmentVariables.set("OAUTH_CLIENT_ID", "invalidClientId")
         environmentVariables.set("OAUTH_CLIENT_SECRET", "invalidClientSecret")
-        val client = OAuthClient()
+        val client = OAuthClient(credentialProvider = EnvironmentVariableCredentialProvider())
         client.login()
     }
 }


### PR DESCRIPTION
As environment variable credentials are not possible to set in Android, this PR creates a CredentialProvider interface that can specify behaviour of where to load credentials from.
This PR introduces 2 mechanisms to load Sypht credentials:

- Environment variable / Path variable (old behaviour)
- Basic authentication (takes constructor arguments for id and secret)

In order to maintain backward compatibility, the environment variable implementation is the default behaviour. The basic authentication also opens up the possibility of using this library on as many platforms as possible.

Unit tests have been added to ensure values are set correctly.